### PR TITLE
Feature/CUSTO-49 Magento 2.4.8 support

### DIFF
--- a/Api/MappedDataBuilderInterface.php
+++ b/Api/MappedDataBuilderInterface.php
@@ -12,5 +12,5 @@ interface MappedDataBuilderInterface
      *
      * @return \Magento\Framework\DataObject
      */
-    public function buildMappedData($entity, int $storeId = null);
+    public function buildMappedData($entity, ?int $storeId = null);
 }

--- a/Api/MappingDataProviderInterface.php
+++ b/Api/MappingDataProviderInterface.php
@@ -11,7 +11,7 @@ interface MappingDataProviderInterface
      *
      * @return \Custobar\CustoConnector\Api\Data\MappingDataInterface[]
      */
-    public function getAllMappingData(int $storeId = null);
+    public function getAllMappingData(?int $storeId = null);
 
     /**
      * Returns entity specific mapping data by type
@@ -21,7 +21,7 @@ interface MappingDataProviderInterface
      *
      * @return \Custobar\CustoConnector\Api\Data\MappingDataInterface
      */
-    public function getMappingDataByEntityType(string $entityType, int $storeId = null);
+    public function getMappingDataByEntityType(string $entityType, ?int $storeId = null);
 
     /**
      * Returns entity specific mapping data by target field
@@ -31,7 +31,7 @@ interface MappingDataProviderInterface
      *
      * @return \Custobar\CustoConnector\Api\Data\MappingDataInterface
      */
-    public function getMappingDataByTargetField(string $targetField, int $storeId = null);
+    public function getMappingDataByTargetField(string $targetField, ?int $storeId = null);
 
     /**
      * Returns entity specific mapping data by entity object
@@ -41,5 +41,5 @@ interface MappingDataProviderInterface
      *
      * @return \Custobar\CustoConnector\Api\Data\MappingDataInterface
      */
-    public function getMappingDataByObject($entity, int $storeId = null);
+    public function getMappingDataByObject($entity, ?int $storeId = null);
 }

--- a/Model/MappedDataBuilder.php
+++ b/Model/MappedDataBuilder.php
@@ -62,7 +62,7 @@ class MappedDataBuilder implements MappedDataBuilderInterface
     /**
      * @inheritDoc
      */
-    public function buildMappedData($entity, int $storeId = null)
+    public function buildMappedData($entity, ?int $storeId = null)
     {
         $entityType = $this->identiferResolver->resolveEntityType($entity);
         if ($entityType == Product::ENTITY) {

--- a/Model/MappingDataProvider.php
+++ b/Model/MappingDataProvider.php
@@ -57,7 +57,7 @@ class MappingDataProvider implements MappingDataProviderInterface
     /**
      * @inheritDoc
      */
-    public function getAllMappingData(int $storeId = null)
+    public function getAllMappingData(?int $storeId = null)
     {
         if (!isset($this->cachedData[$storeId])) {
             $mappingModels = $this->resolveValidModels();
@@ -79,7 +79,7 @@ class MappingDataProvider implements MappingDataProviderInterface
     /**
      * @inheritDoc
      */
-    public function getMappingDataByEntityType(string $entityType, int $storeId = null)
+    public function getMappingDataByEntityType(string $entityType, ?int $storeId = null)
     {
         $models = $this->getAllMappingData($storeId);
 
@@ -89,7 +89,7 @@ class MappingDataProvider implements MappingDataProviderInterface
     /**
      * @inheritDoc
      */
-    public function getMappingDataByTargetField(string $targetField, int $storeId = null)
+    public function getMappingDataByTargetField(string $targetField, ?int $storeId = null)
     {
         $models = $this->getAllMappingData($storeId);
         foreach ($models as $model) {
@@ -104,7 +104,7 @@ class MappingDataProvider implements MappingDataProviderInterface
     /**
      * @inheritDoc
      */
-    public function getMappingDataByObject($entity, int $storeId = null)
+    public function getMappingDataByObject($entity, ?int $storeId = null)
     {
         $entityType = $this->typeResolver->resolveEntityType($entity);
 

--- a/Model/MappingDataProvider/DataExtender/AdjustFieldMappingFromConfig.php
+++ b/Model/MappingDataProvider/DataExtender/AdjustFieldMappingFromConfig.php
@@ -26,7 +26,7 @@ class AdjustFieldMappingFromConfig implements DataExtenderInterface
     /**
      * @inheritDoc
      */
-    public function extendData(MappingDataInterface $mappingData, int $storeId = null)
+    public function extendData(MappingDataInterface $mappingData, ?int $storeId = null)
     {
         $configPath = $mappingData->getFieldMapConfig();
         if (!$configPath) {

--- a/Model/MappingDataProvider/DataExtender/ApplyDomainOnFieldMapping.php
+++ b/Model/MappingDataProvider/DataExtender/ApplyDomainOnFieldMapping.php
@@ -35,7 +35,7 @@ class ApplyDomainOnFieldMapping implements DataExtenderInterface
     /**
      * @inheritDoc
      */
-    public function extendData(MappingDataInterface $mappingData, int $storeId = null)
+    public function extendData(MappingDataInterface $mappingData, ?int $storeId = null)
     {
         $domain = $this->config->getApiPrefix();
         $fieldMapping = $mappingData->getFieldMap() ?? [];

--- a/Model/MappingDataProvider/DataExtenderChain.php
+++ b/Model/MappingDataProvider/DataExtenderChain.php
@@ -24,7 +24,7 @@ class DataExtenderChain implements DataExtenderInterface
     /**
      * @inheritDoc
      */
-    public function extendData(MappingDataInterface $mappingData, int $storeId = null)
+    public function extendData(MappingDataInterface $mappingData, ?int $storeId = null)
     {
         foreach ($this->dataExtenders as $name => $dataExtender) {
             if ($dataExtender === null) {

--- a/Model/MappingDataProvider/DataExtenderInterface.php
+++ b/Model/MappingDataProvider/DataExtenderInterface.php
@@ -14,5 +14,5 @@ interface DataExtenderInterface
      *
      * @return MappingDataInterface
      */
-    public function extendData(MappingDataInterface $mappingData, int $storeId = null);
+    public function extendData(MappingDataInterface $mappingData, ?int $storeId = null);
 }

--- a/Test/Integration/Controller/Adminhtml/Status/CancelTest.php
+++ b/Test/Integration/Controller/Adminhtml/Status/CancelTest.php
@@ -18,6 +18,16 @@ use Magento\TestFramework\TestCase\AbstractBackendController;
 class CancelTest extends AbstractBackendController
 {
     /**
+     * @inheritDoc
+     */
+    protected $resource = 'Custobar_CustoConnector::status';
+
+    /**
+     * @inheritDoc
+     */
+    protected $uri = 'backend/custobar/status/cancel';
+
+    /**
      * @var ObjectManagerInterface
      */
     private $objectManager;
@@ -33,9 +43,6 @@ class CancelTest extends AbstractBackendController
      */
     protected function setUp(): void
     {
-        $this->resource = 'Custobar_CustoConnector::status';
-        $this->uri = 'backend/custobar/status/cancel';
-
         parent::setUp();
 
         $this->objectManager = Bootstrap::getObjectManager();
@@ -59,7 +66,7 @@ class CancelTest extends AbstractBackendController
 
         $this->getRequest()->setMethod(HttpRequest::METHOD_POST);
         $this->getRequest()->setPostValue(['identifier' => 'products']);
-        $this->dispatch('backend/custobar/status/cancel');
+        $this->dispatch($this->uri);
 
         $this->assertSessionMessages(
             $this->equalTo(['Successfully canceled all running exports']),
@@ -84,16 +91,11 @@ class CancelTest extends AbstractBackendController
 
         $this->getRequest()->setMethod(HttpRequest::METHOD_POST);
         $this->getRequest()->setPostValue(['identifier' => 'products']);
-        $this->dispatch('backend/custobar/status/cancel');
+        $this->dispatch($this->uri);
 
         $this->assertSessionMessages(
-            $this->equalTo([
-                \sprintf(
-                    'No initial found with id \'%s\'',
-                    \Magento\Catalog\Model\Product::class
-                ),
-            ]),
-            MessageInterface::TYPE_SUCCESS
+            $this->equalTo(['No exports to cancel']),
+            MessageInterface::TYPE_WARNING
         );
         $this->assertRedirect($this->stringContains('/backend/custobar/status/index'));
     }
@@ -110,11 +112,11 @@ class CancelTest extends AbstractBackendController
 
         $this->getRequest()->setMethod(HttpRequest::METHOD_POST);
         $this->getRequest()->setPostValue(['identifier' => 'unknown_type']);
-        $this->dispatch('backend/custobar/status/cancel');
+        $this->dispatch($this->uri);
 
         $this->assertSessionMessages(
-            $this->equalTo(['No initial found with id \'unknown_type\'']),
-            MessageInterface::TYPE_SUCCESS
+            $this->equalTo(['Cannot start export for unconfigured type &#039;unknown_type&#039;']),
+            MessageInterface::TYPE_ERROR
         );
         $this->assertRedirect($this->stringContains('/backend/custobar/status/index'));
     }
@@ -152,7 +154,7 @@ class CancelTest extends AbstractBackendController
 
         $this->getRequest()->setMethod(HttpRequest::METHOD_POST);
         $this->getRequest()->setPostValue(['identifier' => 'all']);
-        $this->dispatch('backend/custobar/status/cancel');
+        $this->dispatch($this->uri);
 
         $this->assertSessionMessages(
             $this->equalTo(['Successfully canceled all running exports']),
@@ -180,8 +182,12 @@ class CancelTest extends AbstractBackendController
 
         foreach ($allExpectedData as $entityType => $expectedData) {
             if (!\is_array($expectedData)) {
-                $this->expectException(NoSuchEntityException::class);
-                $this->initialRepository->getByEntityType($entityType);
+                try {
+                    $this->initialRepository->getByEntityType($entityType);
+                    $this->assertTrue(false, 'Should not find initial of type \'' . $entityType . '\'');
+                } catch (NoSuchEntityException $exception) {
+                    $this->assertTrue(true, 'Should not find initial of type \'' . $entityType . '\'');
+                }
 
                 continue;
             }

--- a/Test/Integration/Controller/Adminhtml/Status/CancelTest.php
+++ b/Test/Integration/Controller/Adminhtml/Status/CancelTest.php
@@ -18,12 +18,12 @@ use Magento\TestFramework\TestCase\AbstractBackendController;
 class CancelTest extends AbstractBackendController
 {
     /**
-     * @inheritDoc
+     * @var string
      */
     protected $resource = 'Custobar_CustoConnector::status';
 
     /**
-     * @inheritDoc
+     * @var string
      */
     protected $uri = 'backend/custobar/status/cancel';
 

--- a/Test/Integration/Model/CustobarApi/ClientBuilder/VersionClientProviderResolver/LaminasClientTest.php
+++ b/Test/Integration/Model/CustobarApi/ClientBuilder/VersionClientProviderResolver/LaminasClientTest.php
@@ -42,7 +42,7 @@ class LaminasClientTest extends TestCase
     /**
      * @return mixed[]
      */
-    public function doesVersionApplyDataProvider()
+    public static function doesVersionApplyDataProvider()
     {
         return [
             'Should return false on 2.4.4' => [

--- a/Test/Integration/Model/CustobarApi/ClientBuilder/VersionClientProviderResolver/ZendClientTest.php
+++ b/Test/Integration/Model/CustobarApi/ClientBuilder/VersionClientProviderResolver/ZendClientTest.php
@@ -42,7 +42,7 @@ class ZendClientTest extends TestCase
     /**
      * @return mixed[]
      */
-    public function doesVersionApplyDataProvider()
+    public static function doesVersionApplyDataProvider()
     {
         return [
             'Should return true on 2.4.4' => [


### PR DESCRIPTION
Following changes make sure that the Custobar module is possible to install and use on Magento 2.4.8 and PHP 8.4. Installing still works on 2.4.4 and above as well, the changes are backwards compatible. There are also some small improvements to tests, although these are not related to the update.

How the changes have been tested:

- We have made sure the installation of the module works for all currently supported Magento versions and editions (except for Cloud) through a CI pipeline
- We have ran the PHPUnit tests included in the module against all currently supported Magento versions and editions (except for Cloud) through a CI pipeline
- We have ran the MFTF tests related to Adobe Commerce Marketplace against all currently supported Magento versions and editions (except for Cloud) through a CI pipeline
- We have ran PHP Code Sniffer (with latest Magento's coding standard) and Mess Detector (with all latest standards) against the module without issues found
- We have tested the installation and module logic manually against 2.4.8 in a local environment and small demo environment