### PR TITLE
Feature/custo 50 new tracking script support

### DIFF
--- a/Block/Statistics.php
+++ b/Block/Statistics.php
@@ -37,13 +37,23 @@ class Statistics extends Template
     }
 
     /**
-     * Get tracking script from config
+     * Get tracking script (v1) from config
      *
      * @return string
      */
     public function getTrackingScript()
     {
         return $this->config->getTrackingScript();
+    }
+
+    /**
+     * Get tracking script (v2) from config
+     *
+     * @return string
+     */
+    public function getTrackingScriptV2()
+    {
+        return $this->config->getTrackingScriptV2();
     }
 
     /**

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -14,6 +14,7 @@ class Config
     public const CONFIG_MODE = self::CONFIG_BASE_ROOT . 'mode';
     public const CONFIG_TRACKING_MODE = self::CONFIG_BASE_ROOT . 'tracking_mode';
     public const CONFIG_TRACKING_SCRIPT = self::CONFIG_BASE_ROOT . 'tracking_script';
+    public const CONFIG_TRACKING_SCRIPT_V2 = self::CONFIG_BASE_ROOT . 'tracking_script_v2';
 
     public const CONFIG_MAPPING_ROOT = 'custobar/custoconnector_field_mapping/';
     public const CONFIG_MAPPING_PRODUCT = self::CONFIG_MAPPING_ROOT . 'product';
@@ -103,7 +104,7 @@ class Config
     }
 
     /**
-     * Get tracking script from config
+     * Get tracking script (v1) from config
      *
      * @return string
      */
@@ -111,6 +112,19 @@ class Config
     {
         return (string)$this->scopeConfig->getValue(
             self::CONFIG_TRACKING_SCRIPT,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
+     * Get tracking script (v2) from config
+     *
+     * @return string
+     */
+    public function getTrackingScriptV2()
+    {
+        return (string)$this->scopeConfig->getValue(
+            self::CONFIG_TRACKING_SCRIPT_V2,
             ScopeInterface::SCOPE_STORE
         );
     }

--- a/Model/Config/Source/TrackingMode.php
+++ b/Model/Config/Source/TrackingMode.php
@@ -10,6 +10,7 @@ class TrackingMode implements OptionSourceInterface
     public const MODE_NONE = 0;
     public const MODE_CUSTOM_SCRIPT = 1;
     public const MODE_GTM = 2;
+    public const MODE_CUSTOM_SCRIPT_V2 = 3;
 
     /**
      * @inheritDoc
@@ -37,8 +38,9 @@ class TrackingMode implements OptionSourceInterface
     {
         return [
             self::MODE_NONE => __('None'),
-            self::MODE_CUSTOM_SCRIPT => __('Custom Script'),
             self::MODE_GTM => __('Google Tag Manager'),
+            self::MODE_CUSTOM_SCRIPT_V2 => __('Custom Script v1'),
+            self::MODE_CUSTOM_SCRIPT => __('Custom Script v2)'),
         ];
     }
 }

--- a/Model/Config/Source/TrackingMode.php
+++ b/Model/Config/Source/TrackingMode.php
@@ -39,8 +39,8 @@ class TrackingMode implements OptionSourceInterface
         return [
             self::MODE_NONE => __('None'),
             self::MODE_GTM => __('Google Tag Manager'),
-            self::MODE_CUSTOM_SCRIPT_V2 => __('Custom Script v1'),
-            self::MODE_CUSTOM_SCRIPT => __('Custom Script v2)'),
+            self::MODE_CUSTOM_SCRIPT => __('Custom Script (v1)'),
+            self::MODE_CUSTOM_SCRIPT_V2 => __('Custom Script (v2)'),
         ];
     }
 }

--- a/Test/Integration/Block/StatisticsTest.php
+++ b/Test/Integration/Block/StatisticsTest.php
@@ -289,4 +289,60 @@ class StatisticsTest extends AbstractController
             'Assert that GTM script is not added'
         );
     }
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     *
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/allowed_websites 1
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/prefix prefixthatdoesntexists
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/apikey prefixthatdoesntexists
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_mode 3
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script
+     */
+    public function testCustomScriptV2NoTrackingScript()
+    {
+        $this->assertEmpty($this->statistics->getTrackingScript());
+
+        $this->dispatch('/');
+        $html = $this->getResponse()->getBody();
+
+        $this->assertFalse(
+            \str_contains($html, 'v1/custobar.js'),
+            'Assert that code is not present as its set to empty'
+        );
+        $this->assertFalse(
+            \str_contains($html, '<script async src>'),
+            'Assert that script is not present as its set to empty'
+        );
+        $this->assertFalse(
+            \str_contains($html, 'window.dataLayer.push(gtmData)'),
+            'Assert that GTM script is not added instead'
+        );
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     *
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/allowed_websites 1
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/prefix prefixthatdoesntexists
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/apikey prefixthatdoesntexists
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_mode 3
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script <script async src>
+     */
+    public function testCustomScriptV2TrackingScript()
+    {
+        $this->dispatch('/');
+        $html = $this->getResponse()->getBody();
+
+        $this->assertTrue(
+            \str_contains($html, '<script async src>'),
+            'Assert that code is not present as its set to empty'
+        );
+        $this->assertFalse(
+            \str_contains($html, '<script><script async src>'),
+            'Assert that script is not wrapped in another script tag'
+        );
+    }
 }

--- a/Test/Integration/Block/StatisticsTest.php
+++ b/Test/Integration/Block/StatisticsTest.php
@@ -87,6 +87,7 @@ class StatisticsTest extends AbstractController
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/apikey prefixthatdoesntexists
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_mode 1
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script v1/custobar.js
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script_v2 <script async src>
      */
     public function testCustomScriptNotLoggedIn()
     {
@@ -108,6 +109,10 @@ class StatisticsTest extends AbstractController
         $this->assertFalse(
             \str_contains($html, 'window.dataLayer.push(gtmData)'),
             'Assert that GTM script is not added instead'
+        );
+        $this->assertFalse(
+            \str_contains($html, '<script async src>'),
+            'Assert that V2 script is not added'
         );
     }
 
@@ -157,6 +162,7 @@ class StatisticsTest extends AbstractController
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/apikey prefixthatdoesntexists
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_mode 1
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script v1/custobar.js
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script_v2 <script async src>
      */
     public function testCustomScriptLoggedIn()
     {
@@ -185,6 +191,10 @@ class StatisticsTest extends AbstractController
         $this->assertTrue(
             \str_contains($html, 'cstbrConfig.productId = "simple_product_1";'),
             'Is cb.track_browse_product present'
+        );
+        $this->assertFalse(
+            \str_contains($html, '<script async src>'),
+            'Assert that V2 script is not added'
         );
     }
 
@@ -241,6 +251,7 @@ class StatisticsTest extends AbstractController
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/apikey prefixthatdoesntexists
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_mode 1
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script v1/custobar.js
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script_v2 <script async src>
      */
     public function testCustomScriptWebsiteNotAllowed()
     {
@@ -257,6 +268,10 @@ class StatisticsTest extends AbstractController
         $this->assertFalse(
             \str_contains($html, 'v1/custobar.js'),
             'Assert that custobar code is not present'
+        );
+        $this->assertFalse(
+            \str_contains($html, '<script async src>'),
+            'Assert that V2 script is not added'
         );
     }
 
@@ -298,7 +313,7 @@ class StatisticsTest extends AbstractController
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/prefix prefixthatdoesntexists
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/apikey prefixthatdoesntexists
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_mode 3
-     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script_v2
      */
     public function testCustomScriptV2NoTrackingScript()
     {
@@ -329,16 +344,21 @@ class StatisticsTest extends AbstractController
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/prefix prefixthatdoesntexists
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/apikey prefixthatdoesntexists
      * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_mode 3
-     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script <script async src>
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script v1/custobar.js
+     * @magentoConfigFixture default_store custobar/custobar_custoconnector/tracking_script_v2 <script async src>
      */
     public function testCustomScriptV2TrackingScript()
     {
         $this->dispatch('/');
         $html = $this->getResponse()->getBody();
 
+        $this->assertFalse(
+            \str_contains($html, 'v1/custobar.js'),
+            'Assert that V1 script is not added'
+        );
         $this->assertTrue(
             \str_contains($html, '<script async src>'),
-            'Assert that code is not present as its set to empty'
+            'Assert that V2 script is present'
         );
         $this->assertFalse(
             \str_contains($html, '<script><script async src>'),

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -32,7 +32,7 @@
                     <label>Tracking Script</label>
                     <comment>Paste your tracking script here</comment>
                     <depends>
-                        <field id="tracking_mode">1</field>
+                        <field id="tracking_mode" separator="|">1|3</field>
                     </depends>
                 </field>
                 <field id="allowed_websites" translate="label" type="multiselect" sortOrder="600" showInDefault="1" showInWebsite="0" showInStore="0">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -29,10 +29,17 @@
                     <source_model>Custobar\CustoConnector\Model\Config\Source\TrackingMode</source_model>
                 </field>
                 <field id="tracking_script" translate="label" type="textarea" sortOrder="500" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Tracking Script</label>
+                    <label>Tracking Script (v1)</label>
                     <comment>Paste your tracking script here</comment>
                     <depends>
-                        <field id="tracking_mode" separator="|">1|3</field>
+                        <field id="tracking_mode">1</field>
+                    </depends>
+                </field>
+                <field id="tracking_script_v2" translate="label" type="textarea" sortOrder="500" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Tracking Script (v2)</label>
+                    <comment>Paste your tracking script here</comment>
+                    <depends>
+                        <field id="tracking_mode">3</field>
                     </depends>
                 </field>
                 <field id="allowed_websites" translate="label" type="multiselect" sortOrder="600" showInDefault="1" showInWebsite="0" showInStore="0">

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -13,6 +13,11 @@
                            class="Custobar\CustoConnector\Block\Statistics\Config\Customer"
                            template="custoconnector/statistics/config/customer.phtml" />
                 </block>
+                <block name="custobar_statistics_custom_script_v2"
+                       as="custom_script_v2"
+                       class="Custobar\CustoConnector\Block\Statistics"
+                       template="custoconnector/statistics/custom-script-v2.phtml">
+                </block>
                 <block name="custobar_statistics_gtm"
                        as="gtm"
                        class="Custobar\CustoConnector\Block\Statistics\GTM"

--- a/view/frontend/templates/custoconnector/statistics.phtml
+++ b/view/frontend/templates/custoconnector/statistics.phtml
@@ -10,7 +10,9 @@ use Custobar\CustoConnector\Model\Config\Source\TrackingMode;
     <?php if ($block->getTrackingMode() == TrackingMode::MODE_CUSTOM_SCRIPT): ?>
         <?= $block->getChildHtml('custom_script'); ?>
     <?php endif; ?>
-
+    <?php if ($block->getTrackingMode() == TrackingMode::MODE_CUSTOM_SCRIPT_V2): ?>
+        <?= $block->getChildHtml('custom_script_v2'); ?>
+    <?php endif; ?>
     <?php if ($block->getTrackingMode() == TrackingMode::MODE_GTM): ?>
         <?= $block->getChildHtml('gtm'); ?>
     <?php endif; ?>

--- a/view/frontend/templates/custoconnector/statistics/custom-script-v2.phtml
+++ b/view/frontend/templates/custoconnector/statistics/custom-script-v2.phtml
@@ -5,7 +5,7 @@ use Custobar\CustoConnector\Block\Statistics;
 /* @var Statistics $block */
 ?>
 
-<?php $trackingScript = $block->getTrackingScript(); ?>
+<?php $trackingScript = $block->getTrackingScriptV2(); ?>
 <?php if ($trackingScript): ?>
     <?= /* @noEscape */ $trackingScript; ?>
 <?php endif; ?>

--- a/view/frontend/templates/custoconnector/statistics/custom-script-v2.phtml
+++ b/view/frontend/templates/custoconnector/statistics/custom-script-v2.phtml
@@ -1,0 +1,11 @@
+<?php
+
+use Custobar\CustoConnector\Block\Statistics;
+
+/* @var Statistics $block */
+?>
+
+<?php $trackingScript = $block->getTrackingScript(); ?>
+<?php if ($trackingScript): ?>
+    <?= /* @noEscape */ $trackingScript; ?>
+<?php endif; ?>


### PR DESCRIPTION
## PR target
Targeting intentionally the dev branch so the changes can be run through the usual testing processes without affecting master.

## Changes
The changes here implement support to allow passing the tracking script from Magento admin configurations in the new format:

```
<script src="https://script.custobar.com/....." async></script>
```

Previously this wasn't possible, since the script would get wrapped <script> tags.

The previous approach is still available and the new script format is intentionally added behind a new "Tracking Script Mode" option to maintain backwards compatibility. The configuration for the new script is also separate to allow users switching between the previous and new scripts.