### PR TITLE
Feature/custo 51 msi data to product export

### DIFF
--- a/Model/MappedDataBuilder/DataExtender/CatalogProduct/AddInventoryData.php
+++ b/Model/MappedDataBuilder/DataExtender/CatalogProduct/AddInventoryData.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Custobar\CustoConnector\Model\MappedDataBuilder\DataExtender\CatalogProduct;
+
+use Custobar\CustoConnector\Model\MappedDataBuilder\DataExtenderInterface;
+use Magento\Catalog\Model\Product;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+
+class AddInventoryData implements DataExtenderInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function execute($entity)
+    {
+        /** @var Product $entity */
+
+        $stockData = [];
+        /** @var SourceItemInterface[] $sourceItems */
+        $sourceItems = $entity->getExportSourceItems() ?? [];
+        foreach ($sourceItems as $sourceItem) {
+            $stockData[] = [
+                'shop_id' => $sourceItem->getSourceCode(),
+                'quantity' => $sourceItem->getQuantity(),
+            ];
+        }
+
+        $entity->setData('custobar_stock', $stockData);
+
+        return $entity;
+    }
+}

--- a/Model/ResourceModel/Product/ProductProvider/CollectionPostProcessor/AddInventoryData.php
+++ b/Model/ResourceModel/Product/ProductProvider/CollectionPostProcessor/AddInventoryData.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Custobar\CustoConnector\Model\ResourceModel\Product\ProductProvider\CollectionPostProcessor;
+
+use Custobar\CustoConnector\Model\ResourceModel\Product\ProductProvider\CollectionProcessorInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Inventory\Model\ResourceModel\SourceItem\CollectionFactory;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\Data\StockSourceLinkInterface;
+use Magento\InventoryApi\Api\GetStockSourceLinksInterface;
+use Magento\InventoryCatalog\Model\GetStockIdForByStoreId;
+
+class AddInventoryData implements CollectionProcessorInterface
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @var GetStockIdForByStoreId
+     */
+    private $stockIdProvider;
+
+    /**
+     * @var GetStockSourceLinksInterface
+     */
+    private $getStockSourceLinks;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $criteriaBuilder;
+
+    /**
+     * @param CollectionFactory $collectionFactory
+     * @param GetStockIdForByStoreId $stockIdProvider
+     * @param GetStockSourceLinksInterface $getStockSourceLinks
+     * @param SearchCriteriaBuilder $criteriaBuilder
+     */
+    public function __construct(
+        CollectionFactory $collectionFactory,
+        GetStockIdForByStoreId $stockIdProvider,
+        GetStockSourceLinksInterface $getStockSourceLinks,
+        SearchCriteriaBuilder $criteriaBuilder
+    ) {
+        $this->collectionFactory = $collectionFactory;
+        $this->stockIdProvider = $stockIdProvider;
+        $this->getStockSourceLinks = $getStockSourceLinks;
+        $this->criteriaBuilder = $criteriaBuilder;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute($collection)
+    {
+        $skus = $collection->getColumnValues(ProductInterface::SKU);
+        $storeId = (int) $collection->getStoreId();
+        $sourceCodes = $this->getSourceCodesByStoreId($storeId);
+
+        /** @var SourceItemInterface[] $sourceItems */
+        $sourceItems = $this->collectionFactory->create()
+            ->addFieldToFilter(SourceItemInterface::SKU, ['in' => $skus])
+            ->addFieldToFilter(SourceItemInterface::SOURCE_CODE, ['in' => $sourceCodes]);
+        foreach ($sourceItems as $sourceItem) {
+            $sku = $sourceItem->getSku();
+            $product = $collection->getItemByColumnValue(ProductInterface::SKU, $sku);
+            if (!$product) {
+                continue;
+            }
+
+            $qty = $sourceItem->getQuantity();
+            if ($sourceItem->getStatus() === SourceItemInterface::STATUS_OUT_OF_STOCK) {
+                $qty = 0;
+            }
+
+            $sourceItem->setQuantity($qty);
+
+            $productSourceItems = $product->getExportSourceItems() ?? [];
+            $productSourceItems[$sourceItem->getSourceCode()] = $sourceItem;
+            $product->setExportSourceItems($productSourceItems);
+        }
+
+        return $collection;
+    }
+
+    /**
+     * Resolves array of source code strings by store - stock links
+     *
+     * @param int $storeId
+     *
+     * @return string[]
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    private function getSourceCodesByStoreId(int $storeId)
+    {
+        $stockId = $this->stockIdProvider->execute($storeId);
+
+        $searchCriteria = $this->criteriaBuilder
+            ->addFilter(StockSourceLinkInterface::STOCK_ID, $stockId)
+            ->create();
+        $sourceLinks = $this->getStockSourceLinks->execute($searchCriteria);
+
+        return \array_map(function ($sourceLink) {
+            return (string) $sourceLink->getSourceCode();
+        }, $sourceLinks->getItems());
+    }
+}

--- a/Model/ResourceModel/Product/ProductProvider/CollectionPostProcessor/AddInventoryData.php
+++ b/Model/ResourceModel/Product/ProductProvider/CollectionPostProcessor/AddInventoryData.php
@@ -4,13 +4,11 @@ namespace Custobar\CustoConnector\Model\ResourceModel\Product\ProductProvider\Co
 
 use Custobar\CustoConnector\Model\ResourceModel\Product\ProductProvider\CollectionProcessorInterface;
 use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Inventory\Model\ResourceModel\SourceItem\CollectionFactory;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
-use Magento\InventoryApi\Api\Data\StockSourceLinkInterface;
-use Magento\InventoryApi\Api\GetStockSourceLinksInterface;
 use Magento\InventoryCatalog\Model\GetStockIdForByStoreId;
 
 class AddInventoryData implements CollectionProcessorInterface
@@ -26,31 +24,15 @@ class AddInventoryData implements CollectionProcessorInterface
     private $stockIdProvider;
 
     /**
-     * @var GetStockSourceLinksInterface
-     */
-    private $getStockSourceLinks;
-
-    /**
-     * @var SearchCriteriaBuilder
-     */
-    private $criteriaBuilder;
-
-    /**
      * @param CollectionFactory $collectionFactory
      * @param GetStockIdForByStoreId $stockIdProvider
-     * @param GetStockSourceLinksInterface $getStockSourceLinks
-     * @param SearchCriteriaBuilder $criteriaBuilder
      */
     public function __construct(
         CollectionFactory $collectionFactory,
-        GetStockIdForByStoreId $stockIdProvider,
-        GetStockSourceLinksInterface $getStockSourceLinks,
-        SearchCriteriaBuilder $criteriaBuilder
+        GetStockIdForByStoreId $stockIdProvider
     ) {
         $this->collectionFactory = $collectionFactory;
         $this->stockIdProvider = $stockIdProvider;
-        $this->getStockSourceLinks = $getStockSourceLinks;
-        $this->criteriaBuilder = $criteriaBuilder;
     }
 
     /**
@@ -58,14 +40,7 @@ class AddInventoryData implements CollectionProcessorInterface
      */
     public function execute($collection)
     {
-        $skus = $collection->getColumnValues(ProductInterface::SKU);
-        $storeId = (int) $collection->getStoreId();
-        $sourceCodes = $this->getSourceCodesByStoreId($storeId);
-
-        /** @var SourceItemInterface[] $sourceItems */
-        $sourceItems = $this->collectionFactory->create()
-            ->addFieldToFilter(SourceItemInterface::SKU, ['in' => $skus])
-            ->addFieldToFilter(SourceItemInterface::SOURCE_CODE, ['in' => $sourceCodes]);
+        $sourceItems = $this->getSourceItemsByProductCollection($collection);
         foreach ($sourceItems as $sourceItem) {
             $sku = $sourceItem->getSku();
             $product = $collection->getItemByColumnValue(ProductInterface::SKU, $sku);
@@ -89,25 +64,34 @@ class AddInventoryData implements CollectionProcessorInterface
     }
 
     /**
-     * Resolves array of source code strings by store - stock links
+     * Based on given collection, retrieves only the relevant source item data for the products
      *
-     * @param int $storeId
+     * @param Collection $collection
      *
-     * @return string[]
+     * @return SourceItemInterface[]
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    private function getSourceCodesByStoreId(int $storeId)
+    private function getSourceItemsByProductCollection($collection)
     {
+        $skus = $collection->getColumnValues(ProductInterface::SKU);
+        $storeId = (int) $collection->getStoreId();
         $stockId = $this->stockIdProvider->execute($storeId);
 
-        $searchCriteria = $this->criteriaBuilder
-            ->addFilter(StockSourceLinkInterface::STOCK_ID, $stockId)
-            ->create();
-        $sourceLinks = $this->getStockSourceLinks->execute($searchCriteria);
+        $collection = $this->collectionFactory->create()
+            ->addFieldToFilter(SourceItemInterface::SKU, ['in' => $skus]);
+        $collection->getSelect()
+            ->joinInner(
+                ['issl' => 'inventory_source_stock_link'],
+                'issl.source_code = main_table.source_code and issl.stock_id = ' . $stockId,
+                []
+            )
+            ->joinInner(
+                ['is' => 'inventory_source'],
+                'issl.source_code = is.source_code and is.enabled = 1',
+                []
+            );
 
-        return \array_map(function ($sourceLink) {
-            return (string) $sourceLink->getSourceCode();
-        }, $sourceLinks->getItems());
+        return $collection->getItems();
     }
 }

--- a/Model/ResourceModel/Product/ProductProvider/CollectionPostProcessor/AddInventoryData.php
+++ b/Model/ResourceModel/Product/ProductProvider/CollectionPostProcessor/AddInventoryData.php
@@ -9,7 +9,9 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Inventory\Model\ResourceModel\SourceItem\CollectionFactory;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
-use Magento\InventoryCatalog\Model\GetStockIdForByStoreId;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\StockResolverInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class AddInventoryData implements CollectionProcessorInterface
 {
@@ -19,20 +21,28 @@ class AddInventoryData implements CollectionProcessorInterface
     private $collectionFactory;
 
     /**
-     * @var GetStockIdForByStoreId
+     * @var StoreManagerInterface
      */
-    private $stockIdProvider;
+    private $storeManager;
+
+    /**
+     * @var StockResolverInterface
+     */
+    private $stockResolver;
 
     /**
      * @param CollectionFactory $collectionFactory
-     * @param GetStockIdForByStoreId $stockIdProvider
+     * @param StoreManagerInterface $storeManager
+     * @param StockResolverInterface $stockResolver
      */
     public function __construct(
         CollectionFactory $collectionFactory,
-        GetStockIdForByStoreId $stockIdProvider
+        StoreManagerInterface $storeManager,
+        StockResolverInterface $stockResolver
     ) {
         $this->collectionFactory = $collectionFactory;
-        $this->stockIdProvider = $stockIdProvider;
+        $this->storeManager = $storeManager;
+        $this->stockResolver = $stockResolver;
     }
 
     /**
@@ -76,7 +86,10 @@ class AddInventoryData implements CollectionProcessorInterface
     {
         $skus = $collection->getColumnValues(ProductInterface::SKU);
         $storeId = (int) $collection->getStoreId();
-        $stockId = $this->stockIdProvider->execute($storeId);
+
+        $websiteId = $this->storeManager->getStore($storeId)->getWebsiteId();
+        $websiteCode = $this->storeManager->getWebsite($websiteId)->getCode();
+        $stockId = $this->stockResolver->execute(SalesChannelInterface::TYPE_WEBSITE, $websiteCode)->getStockId();
 
         $collection = $this->collectionFactory->create()
             ->addFieldToFilter(SourceItemInterface::SKU, ['in' => $skus]);

--- a/README.md
+++ b/README.md
@@ -167,3 +167,4 @@ for export
     custobar_date>date;
     store_id>store_id
    ```
+

--- a/Test/Integration/Model/MappedDataBuilderTest.php
+++ b/Test/Integration/Model/MappedDataBuilderTest.php
@@ -117,6 +117,92 @@ class MappedDataBuilderTest extends TestCase
     }
 
     /**
+     * @dataProvider buildMappedDataProductWithStocksDataProvider
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation disabled
+     * @magentoDataFixture Magento_InventoryApi::Test/_files/products.php
+     * @magentoDataFixture Magento_InventoryApi::Test/_files/sources.php
+     * @magentoDataFixture Magento_InventoryApi::Test/_files/stocks.php
+     * @magentoDataFixture Magento_InventoryApi::Test/_files/stock_source_links.php
+     * @magentoDataFixture Magento_InventoryApi::Test/_files/source_items.php
+     * @magentoDataFixture Magento_InventorySalesApi::Test/_files/websites_with_stores.php
+     * @magentoDataFixture Magento_InventorySalesApi::Test/_files/stock_website_sales_channels.php
+     * @magentoDataFixture Magento_InventoryIndexer::Test/_files/reindex_inventory.php
+     */
+    public function testBuildMappedDataProductWithStocks(string $storeCode, array $expectedStocks)
+    {
+        $skus = \array_keys($expectedStocks);
+        $productIds = \array_map(function ($sku) {
+            return $this->productRepository->get($sku)->getId();
+        }, $skus);
+
+        $mappedData = [];
+        $productDataItems = $this->entityDataResolver->resolveEntities(
+            Product::class,
+            $productIds,
+            $this->storeManager->getStore($storeCode)->getId()
+        );
+        foreach ($productDataItems as $productDataItem) {
+            $mappedData[$productDataItem->getSku()] = $this->mappedDataBuilder->buildMappedData($productDataItem);
+        }
+
+        $mappedStockData = \array_map(function ($mappedData) {
+            return $mappedData->getData('stock');
+        }, $mappedData);
+
+        $this->assertEquals($expectedStocks, $mappedStockData);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public static function buildMappedDataProductWithStocksDataProvider()
+    {
+        return [
+            'should set only stocks on products based on \'store_for_eu_website\'' => [
+                'store_for_eu_website',
+                [
+                    'SKU-1' => [
+                        ['shop_id' => 'eu-1', 'quantity' => 5.5],
+                        ['shop_id' => 'eu-2', 'quantity' => 3],
+                        ['shop_id' => 'eu-3', 'quantity' => 0],
+                    ],
+                    'SKU-2' => [],
+                    'SKU-3' => [
+                        ['shop_id' => 'eu-2', 'quantity' => 0],
+                    ],
+                ],
+            ],
+            'should set only stocks on products based on \'store_for_us_website\'' => [
+                'store_for_us_website',
+                [
+                    'SKU-1' => [],
+                    'SKU-2' => [
+                        ['shop_id' => 'us-1', 'quantity' => 5.0],
+                    ],
+                    'SKU-3' => [],
+                ],
+            ],
+            'should set only stocks on products based on \'store_for_global_website\'' => [
+                'store_for_global_website',
+                [
+                    'SKU-1' => [
+                        ['shop_id' => 'eu-1', 'quantity' => 5.5],
+                        ['shop_id' => 'eu-2', 'quantity' => 3],
+                        ['shop_id' => 'eu-3', 'quantity' => 0],
+                    ],
+                    'SKU-2' => [
+                        ['shop_id' => 'us-1', 'quantity' => 5.0],
+                    ],
+                    'SKU-3' => [
+                        ['shop_id' => 'eu-2', 'quantity' => 0],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
      * @magentoAppIsolation enabled
      * @magentoDbIsolation enabled
      *

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -137,6 +137,7 @@
             <argument name="postProcessors" xsi:type="array">
                 <item name="add_category_data" xsi:type="object">Custobar\CustoConnector\Model\ResourceModel\Product\ProductProvider\CollectionPostProcessor\AddCategoryData</item>
                 <item name="add_url_rewrite_data" xsi:type="object">Custobar\CustoConnector\Model\ResourceModel\Product\ProductProvider\CollectionPostProcessor\AddUrlRewriteData</item>
+                <item name="add_inventory_data" xsi:type="object">Custobar\CustoConnector\Model\ResourceModel\Product\ProductProvider\CollectionPostProcessor\AddInventoryData</item>
             </argument>
         </arguments>
     </type>
@@ -185,6 +186,9 @@
                 <item name="target_field" xsi:type="string">products</item>
                 <item name="label" xsi:type="string" translatable="true">Products</item>
                 <item name="field_map_config" xsi:type="const">Custobar\CustoConnector\Model\Config::CONFIG_MAPPING_PRODUCT</item>
+                <item name="field_map" xsi:type="array">
+                    <item name="custobar_stock" xsi:type="string">stock</item>
+                </item>
             </argument>
         </arguments>
     </virtualType>
@@ -271,6 +275,7 @@
                 <item name="add_bundle_data" xsi:type="object">Custobar\CustoConnector\Model\MappedDataBuilder\DataExtender\CatalogProduct\AddBundleData</item>
                 <item name="add_configurable_data" xsi:type="object">Custobar\CustoConnector\Model\MappedDataBuilder\DataExtender\CatalogProduct\AddConfigurableData</item>
                 <item name="add_grouped_data" xsi:type="object">Custobar\CustoConnector\Model\MappedDataBuilder\DataExtender\CatalogProduct\AddGroupedData</item>
+                <item name="add_inventory_data" xsi:type="object">Custobar\CustoConnector\Model\MappedDataBuilder\DataExtender\CatalogProduct\AddInventoryData</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
### PR target

Targeting intentionally the `dev` branch so the changes can be run through the usual testing processes without affecting master.

### Changes

The changes extend the product export logic to resolve product specific MSI data and include that in the export output. The data is by default added in `stock` field. Example data structure:

```
{
  "stock": [
    {
      "shop_id": "eu-1",
      "quantity": 5.5
    },
    {
      "shop_id": "eu-2",
      "quantity": 3
    },
    {
      "shop_id": "eu-3",
      "quantity": 0
    }
  ],
  "title": "Simple Product 1 Orange",
  "external_id": "SKU-1",
  "minimal_price": 1000,
  "price": 1000,
  "mage_type": "simple",
  "type": "Default",
  "category": "",
  "category_id": "",
  "image": "http:\/\/localhost\/media\/catalog\/product",
  "url": "http:\/\/localhost\/index.php\/catalog\/product\/view\/id\/8649\/s\/simple-product-1-orange\/?___store=store_for_eu_website",
  "sale_price": 0,
  "language": "en",
  "store_id": "184"
}
```

Things to note:

- The logic takes into account the store we're exporting data with. Only sources related to stocks related to the exported store id will be included in the output.
- The logic leaves out sources that are not enabled
- The logic sets the quantity to zero for any source items where stock status has been set to zero
- Other than previous point the quantity is taken directly from source item data, salable quantity (= reservations and minimum quantity config applied on top of the quantity) is not taken into account for now

Changes should be backwards compatible, running the module tests against Magento versions from 2.4.5 to 2.4.8 all pass. The inventory classes referenced here should also exist in versions older than that.

In order to get the `stock` field included in the product export data by default, the field mapping was updated in `etc/di.xml`. This should allow anyone updating the module to get the changes without needing to manually update the mapping configuration. The mapping in configuration can still be used to override the field name if needed.